### PR TITLE
CI: add bundler-cache in 1 location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0
+          bundler-cache: true # 'bundle install' and cache
 
       - uses: actions/checkout@v2
-
-      - run: bundle
 
       - run: bundle exec rake test
 


### PR DESCRIPTION
The other Jobs in the Workflow seemed to have their own relationship to Bundler installation.

---

This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.