### PR TITLE
Fix duplicate joins when filtering same association with string vs symbol keys

### DIFF
--- a/lib/active_record/filter/predicate_builder_extension.rb
+++ b/lib/active_record/filter/predicate_builder_extension.rb
@@ -64,17 +64,17 @@ module ActiveRecord::Filter::PredicateBuilderExtension
                 ]
               else
                 {
-                  key => build_filter_joins(reflection.klass, value, [], custom)
+                  reflection.name => build_filter_joins(reflection.klass, value, [], custom)
                 }
               end
             elsif value.is_a?(Array)
               value.each do |v|
                 relations << {
-                  key => build_filter_joins(reflection.klass, v, [], custom)
+                  reflection.name => build_filter_joins(reflection.klass, v, [], custom)
                 }
               end
             elsif value != true && value != false && value != 'true' && value != 'false' && !value.nil?
-              relations << key
+              relations << reflection.name
             end
           elsif !klass.columns_hash.has_key?(key.to_s) && key.to_s.end_with?('_ids') && reflection = klass._reflections[key.to_s.gsub(/_ids$/, 's').to_sym]
             relations << reflection.name

--- a/test/filter_relationship_test/has_many_test.rb
+++ b/test/filter_relationship_test/has_many_test.rb
@@ -204,6 +204,15 @@ class HasManyFilterTest < ActiveSupport::TestCase
     SQL
   end
 
+  test "::filter chained calls with string and symbol keys reuse the same join" do
+    query = Account.filter('photos' => {'format' => 'jpg'}).filter(photos: {format: 'png'})
+    assert_equal(<<-SQL.strip.gsub(/\s+/, ' '), query.to_sql.strip.gsub('"', ''))
+      SELECT accounts.* FROM accounts
+      LEFT OUTER JOIN photos ON photos.account_id = accounts.id
+      WHERE photos.format = 'jpg' AND photos.format = 'png'
+    SQL
+  end
+
   test "::filter has_many filter_on" do
     query = Account.filter(photos: {no_properties_where_state_is_null: true})
 


### PR DESCRIPTION
## Summary

- Fixes #26: chaining `.filter` calls on the same association where one call uses string keys and another uses symbol keys (e.g. `'memberships' => {...}` vs `memberships: {...}`) produced two separate joins instead of one, because `build_filter_joins` propagated the raw hash `key` (string or symbol) into the join descriptor instead of the normalized `reflection.name`. Since `{'memberships' => [...]}` and `{memberships: [...]}` aren't `==`, ActiveRecord's join dedup treated them as different joins, so the second `.filter` call got aliased (e.g. `memberships_libraries`) and the `WHERE` clause was duplicated.
- `build_filter_joins` now always keys relation join descriptors off `reflection.name`, so joins for the same association resolve to the same key regardless of how the caller wrote it.

## Test plan

- Added a regression test in `test/filter_relationship_test/has_many_test.rb` chaining `.filter('photos' => {...})` and `.filter(photos: {...})` and asserting a single join is produced.
- `bundle exec rake test` — 78 tests, 110 assertions, 0 failures.