### PR TITLE
9.0.0: modernize CI, add CHANGELOG, independent SemVer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sunstone:
+  filter:
     name: ActiveRecord::Filter Test
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 name: CI
 
-on: 
+on:
   push:
+    branches: [ master ]
   pull_request:
-    types: [opened]
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   sunstone:
@@ -14,23 +19,23 @@ jobs:
       fail-fast: false
       matrix:
         rails-version:
-          - 7.2.3
-          - 8.0
-          - 8.1
+          - '8.0'
+          - '8.1'
         ruby-version:
-          - 3.3
-          - 3.4
-          - 4.0
+          - '3.3'
+          - '3.4'
+          - '4.0'
         postgres-version:
-          - 18
+          - '18'
 
     steps:
       - name: Install Postgresql
         run: |
           sudo apt-get -y --purge remove $(sudo apt list --installed | grep postgresql | awk '{print $1}')
           sudo apt-get install curl ca-certificates gnupg
-          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo install -d /etc/apt/keyrings
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/pgdg.gpg
+          sudo sh -c 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update
           sudo apt-get -y install postgresql-${{ matrix.postgres-version }}-postgis-3
           sudo systemctl start postgresql@${{ matrix.postgres-version }}-main.service
@@ -39,12 +44,7 @@ jobs:
           sudo -u postgres createuser runner --superuser
           sudo -u postgres psql -c "ALTER USER runner WITH PASSWORD 'runner';"
 
-      - uses: actions/checkout@v4
-
-      - name: Fix activerecord-postgis-adapter
-        if: ${{ matrix.rails-version == '8.0.1' }}
-        run: |
-          echo "gem 'activerecord-postgis-adapter', github: 'rgeo/activerecord-postgis-adapter'" >> Gemfile
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -52,9 +52,10 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - run: |
-          sed -i -e "s/spec.add_runtime_dependency  *'activerecord',  *'>= [[:digit:]]\+\(\.[[:digit:]]\+\)*'/spec.add_runtime_dependency 'activerecord', '${{ matrix.rails-version }}'/" activerecord-filter.gemspec
+          sed -i -e "s/spec.add_runtime_dependency  *'activerecord',  *'>= [[:digit:]]\+\(\.[[:digit:]]\+\)*'/spec.add_runtime_dependency 'activerecord', '~> ${{ matrix.rails-version }}.0'/" activerecord-filter.gemspec
           cat activerecord-filter.gemspec
-          rm Gemfile.lock
+          grep -q "~> ${{ matrix.rails-version }}.0" activerecord-filter.gemspec || { echo "ERROR: gemspec activerecord pin not applied (anchor changed?)"; exit 1; }
+          rm -f Gemfile.lock
           bundle install --jobs=3 --retry=3
           bundle update --jobs=3 --retry=3
 
@@ -68,21 +69,21 @@ jobs:
       fail-fast: false
       matrix:
         rails-version:
-          - 7.2.3
-          - 8.0.4
-          - 8.1.2
+          - '8.0'
+          - '8.1'
         ruby-version:
-          - 3.4
+          - '3.4'
         postgres-version:
-          - 18
+          - '18'
 
     steps:
       - name: Install Postgresql
         run: |
           sudo apt-get -y --purge remove $(sudo apt list --installed | grep postgresql | awk '{print $1}')
           sudo apt-get install curl ca-certificates gnupg
-          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo install -d /etc/apt/keyrings
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/pgdg.gpg
+          sudo sh -c 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update
           sudo apt-get -y install postgresql-${{ matrix.postgres-version }}-postgis-3
           sudo systemctl start postgresql@${{ matrix.postgres-version }}-main.service
@@ -91,7 +92,7 @@ jobs:
           sudo -u postgres createuser runner --superuser
           sudo -u postgres psql -c "ALTER USER runner WITH PASSWORD 'runner';"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -100,20 +101,35 @@ jobs:
     
       - name: Download Rails
         run: |
-          git clone --branch v${{ matrix.rails-version }} https://github.com/rails/rails.git ~/rails
+          series="${{ matrix.rails-version }}"
+          esc="${series//./\\.}"
+          RAILS_TAG=$(git ls-remote --tags --refs https://github.com/rails/rails.git "v${series}*" \
+            | sed 's,.*refs/tags/,,' \
+            | grep -E "^v${esc}(\.[0-9]+)+$" \
+            | sort -V | tail -1)
+          test -n "$RAILS_TAG" || { echo "No Rails release tag found for series ${series}"; exit 1; }
+          echo "Using latest Rails tag for ${series}: $RAILS_TAG"
+          git clone --branch "$RAILS_TAG" https://github.com/rails/rails.git ~/rails
           pushd ~/rails
           cat /home/runner/work/_temp/*.sh
           sed -i "s/Gem.ruby, '-w'/Gem.ruby, '-w0'/" ~/rails/activerecord/Rakefile
           sed -i "s/t.warning = true/t.warning = false/g" ~/rails/activerecord/Rakefile
           sed -i "/require \"active_record\"/a \$LOAD_PATH.unshift\(File.expand_path\(ENV['GITHUB_WORKSPACE']\)\)\nrequire 'active_record/filter'" ~/rails/activerecord/test/cases/helper.rb
+          grep -q "require 'active_record/filter'" ~/rails/activerecord/test/cases/helper.rb || { echo "ERROR: failed to inject require active_record/filter into helper.rb (anchor changed upstream?)"; exit 1; }
           rm ~/rails/Gemfile.lock
           sed -i "/# Active Record./a gem 'activerecord-filter', require: 'active_record/filter', path: File.expand_path\(ENV['GITHUB_WORKSPACE']\)" ~/rails/Gemfile
+          grep -q "activerecord-filter" ~/rails/Gemfile || { echo "ERROR: failed to inject activerecord-filter into Gemfile (anchor changed upstream?)"; exit 1; }
           cat ~/rails/Gemfile
 
       - name: This can eventually be removed
         run: |
+          # minitest/mock isn't auto-required by the standalone AR suite; force it.
           sed -i 's/gem "minitest"$/gem "minitest"\ngem "minitest-mock", require: "minitest\/mock"/' ~/rails/Gemfile
+          # postgresql_adapter_test.rb references the Rails constant; Rails is
+          # undefined when the suite runs standalone, so stub an empty module.
           sed -i 's/module ActiveRecord$/module Rails\nend\nmodule ActiveRecord/' ~/rails/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb || true
+          # --profile is only a valid option when railties' minitest plugin is
+          # active; it isn't here, so strip it (CI=true would otherwise set it).
           sed -i 's/t.options = "--profile" if ENV\["CI"\]//g' ~/rails/activerecord/Rakefile
 
       - name: Fix Weird Test Cases
@@ -128,8 +144,8 @@ jobs:
 
       - run: |
           pushd ~/rails/activerecord
-          bundle exec rake db:postgresql:rebuild postgresql:test
-          bundle exec rake db:postgresql:rebuild postgresql:isolated_test
+          bundle exec rake db:postgresql:rebuild postgresql:test --trace
+          bundle exec rake db:postgresql:rebuild postgresql:isolated_test --trace
           
   ar-sqlite:
     name: ActiveRecord SQLite Test
@@ -140,14 +156,13 @@ jobs:
       fail-fast: false
       matrix:
         rails-version:
-          - 7.2.3
-          - 8.0.4
-          - 8.1.2
+          - '8.0'
+          - '8.1'
         ruby-version:
-          - 3.4
+          - '3.4'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -156,24 +171,35 @@ jobs:
     
       - name: Download Rails
         run: |
-          git clone --branch v${{ matrix.rails-version }} https://github.com/rails/rails.git ~/rails
+          series="${{ matrix.rails-version }}"
+          esc="${series//./\\.}"
+          RAILS_TAG=$(git ls-remote --tags --refs https://github.com/rails/rails.git "v${series}*" \
+            | sed 's,.*refs/tags/,,' \
+            | grep -E "^v${esc}(\.[0-9]+)+$" \
+            | sort -V | tail -1)
+          test -n "$RAILS_TAG" || { echo "No Rails release tag found for series ${series}"; exit 1; }
+          echo "Using latest Rails tag for ${series}: $RAILS_TAG"
+          git clone --branch "$RAILS_TAG" https://github.com/rails/rails.git ~/rails
           pushd ~/rails
           cat /home/runner/work/_temp/*.sh
           sed -i "s/Gem.ruby, '-w'/Gem.ruby, '-w0'/" ~/rails/activerecord/Rakefile
           sed -i "s/t.warning = true/t.warning = false/g" ~/rails/activerecord/Rakefile
           sed -i "/require \"active_record\"/a \$LOAD_PATH.unshift\(File.expand_path\(ENV['GITHUB_WORKSPACE']\)\)\nrequire 'active_record/filter'" ~/rails/activerecord/test/cases/helper.rb
+          grep -q "require 'active_record/filter'" ~/rails/activerecord/test/cases/helper.rb || { echo "ERROR: failed to inject require active_record/filter into helper.rb (anchor changed upstream?)"; exit 1; }
           rm ~/rails/Gemfile.lock
           sed -i "/# Active Record./a gem 'activerecord-filter', require: 'active_record/filter', path: File.expand_path\(ENV['GITHUB_WORKSPACE']\)" ~/rails/Gemfile
+          grep -q "activerecord-filter" ~/rails/Gemfile || { echo "ERROR: failed to inject activerecord-filter into Gemfile (anchor changed upstream?)"; exit 1; }
           cat ~/rails/Gemfile
 
       - name: This can eventually be removed
         run: |
+          # minitest/mock isn't auto-required by the standalone AR suite; force it.
           sed -i 's/gem "minitest"$/gem "minitest"\ngem "minitest-mock", require: "minitest\/mock"/' ~/rails/Gemfile
-          cat ~/rails/Gemfile
-          sed -i 's/module ActiveRecord$/module Rails\nend\nmodule ActiveRecord/' ~/rails/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
-          cat  ~/rails/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
+          # dbconsole_test.rb references the Rails constant; stub an empty module.
+          sed -i 's/module ActiveRecord$/module Rails\nend\nmodule ActiveRecord/' ~/rails/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb || true
+          # --profile is only a valid option when railties' minitest plugin is
+          # active; it isn't here, so strip it (CI=true would otherwise set it).
           sed -i 's/t.options = "--profile" if ENV\["CI"\]//g' ~/rails/activerecord/Rakefile
-          cat ~/rails/activerecord/Rakefile
       
       - name: Fix Weird Test Cases
         run: |
@@ -187,11 +213,11 @@ jobs:
 
       - run: |
           pushd ~/rails/activerecord
-          bundle exec rake sqlite3:test
+          bundle exec rake sqlite3:test --trace
           rm test/db/*.sqlite3 test/fixtures/*.sqlite3
-          bundle exec rake sqlite3:isolated_test
+          bundle exec rake sqlite3:isolated_test --trace
           rm test/db/*.sqlite3 test/fixtures/*.sqlite3
-          bundle exec rake sqlite3_mem:test
+          bundle exec rake sqlite3_mem:test --trace
         
   ar-mysql:
     name: ActiveRecord MySQL Test
@@ -201,20 +227,36 @@ jobs:
       fail-fast: false
       matrix:
         rails-version:
-          - 7.2.3
-          - 8.0.4
-          - 8.1.2
+          - '8.0'
+          - '8.1'
         ruby-version:
-          - 3.4
+          - '3.4'
+        mysql-version:
+          - '8.4'
+    env:
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_PORT: 3306
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql-version }}
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_ROOT_HOST: "%"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h127.0.0.1 -uroot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
 
     steps:
-      - name: Install MySQL
+      - name: Setup MySQL user
         run: |
-          sudo /etc/init.d/mysql start
-          mysql -uroot -proot -e "CREATE USER 'rails'@'%';"
-          mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%' WITH GRANT OPTION;"
+          mysql -h127.0.0.1 -P3306 -uroot -e "CREATE USER 'rails'@'%';"
+          mysql -h127.0.0.1 -P3306 -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%' WITH GRANT OPTION;"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -223,23 +265,37 @@ jobs:
 
       - name: Download Rails
         run: |
-          git clone --branch v${{ matrix.rails-version }} https://github.com/rails/rails.git ~/rails
+          series="${{ matrix.rails-version }}"
+          esc="${series//./\\.}"
+          RAILS_TAG=$(git ls-remote --tags --refs https://github.com/rails/rails.git "v${series}*" \
+            | sed 's,.*refs/tags/,,' \
+            | grep -E "^v${esc}(\.[0-9]+)+$" \
+            | sort -V | tail -1)
+          test -n "$RAILS_TAG" || { echo "No Rails release tag found for series ${series}"; exit 1; }
+          echo "Using latest Rails tag for ${series}: $RAILS_TAG"
+          git clone --branch "$RAILS_TAG" https://github.com/rails/rails.git ~/rails
           pushd ~/rails
           cat /home/runner/work/_temp/*.sh
           sed -i "s/Gem.ruby, '-w'/Gem.ruby, '-w0'/" ~/rails/activerecord/Rakefile
           sed -i "s/t.warning = true/t.warning = false/g" ~/rails/activerecord/Rakefile
           sed -i "/require \"active_record\"/a \$LOAD_PATH.unshift\(File.expand_path\(ENV['GITHUB_WORKSPACE']\)\)\nrequire 'active_record/filter'" ~/rails/activerecord/test/cases/helper.rb
+          grep -q "require 'active_record/filter'" ~/rails/activerecord/test/cases/helper.rb || { echo "ERROR: failed to inject require active_record/filter into helper.rb (anchor changed upstream?)"; exit 1; }
           rm ~/rails/Gemfile.lock
           sed -i "/# Active Record./a gem 'activerecord-filter', require: 'active_record/filter', path: File.expand_path\(ENV['GITHUB_WORKSPACE']\)" ~/rails/Gemfile
+          grep -q "activerecord-filter" ~/rails/Gemfile || { echo "ERROR: failed to inject activerecord-filter into Gemfile (anchor changed upstream?)"; exit 1; }
           cat ~/rails/Gemfile
 
       - name: This can eventually be removed
         run: |
+          # minitest/mock isn't auto-required by the standalone AR suite; force it.
           sed -i 's/gem "minitest"$/gem "minitest"\ngem "minitest-mock", require: "minitest\/mock"/' ~/rails/Gemfile
+          # warnings_test.rb / mysql2_adapter_test.rb reference the Rails constant;
+          # Rails is undefined when the suite runs standalone, so stub an empty module.
           sed -i 's/class WarningsTest < ActiveRecord::AbstractMysqlTestCase$/module Rails\nend\nclass WarningsTest < ActiveRecord::AbstractMysqlTestCase/' ~/rails/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb || true
           sed -i 's/class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase$/module Rails\nend\nclass Mysql2AdapterTest < ActiveRecord::Mysql2TestCase/' ~/rails/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb || true
+          # --profile is only a valid option when railties' minitest plugin is
+          # active; it isn't here, so strip it (CI=true would otherwise set it).
           sed -i 's/t.options = "--profile" if ENV\["CI"\]//g' ~/rails/activerecord/Rakefile
-          cat ~/rails/activerecord/Rakefile
 
 
       - name: Fix Weird Test Cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## [9.0.0] - Unreleased
+
+### Changed
+- Switched to independent Semantic Versioning. Prior releases tracked the Rails
+  major/minor line; the version number no longer maps to a Rails version.
+- Require Ruby >= 3.3.
+- Require ActiveRecord >= 8.0 (dropped support for Rails older than 8.0).
+
+### Added
+- Gemspec `metadata` (source code, changelog, MFA-required).
+
+### CI
+- Modernized the workflow: test the Rails 8.0 and 8.1 series (resolving the
+  latest patch release automatically), scope triggers to `master` with a
+  cancel-in-progress concurrency group, replace the deprecated `apt-key` with a
+  keyring, run MySQL as a service container, guard the sed/injection steps so a
+  silent no-op fails the build, and bump `actions/checkout` to v7.
+
+### Packaging
+- Removed the deprecated `test_files` gemspec declaration.
+
+### Documentation
+- Expanded the README: AND/OR grouping, filtering across associations
+  (including polymorphic), and the supported column-type predicates.
+
+## Earlier releases
+
+Prior versions tracked the matching Rails release. See the Git history and
+RubyGems for details:
+
+- [8.1.0] - 2026-01-06
+- [8.0.0] - 2025-01-28
+- [7.0.1] - 2024-09-09
+- [7.0.0] - 2022-12-07
+- [6.1.0] - 2021-01-14
+- [6.0.0.7] - 2020-06-26
+
+[9.0.0]: https://github.com/malomalo/activerecord-filter/compare/v8.1.0...master
+[8.1.0]: https://rubygems.org/gems/activerecord-filter/versions/8.1.0
+[8.0.0]: https://rubygems.org/gems/activerecord-filter/versions/8.0.0
+[7.0.1]: https://rubygems.org/gems/activerecord-filter/versions/7.0.1
+[7.0.0]: https://rubygems.org/gems/activerecord-filter/versions/7.0.0
+[6.1.0]: https://github.com/malomalo/activerecord-filter/releases/tag/v6.1.0
+[6.0.0.7]: https://github.com/malomalo/activerecord-filter/releases/tag/v6.0.0.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Specify your gem's dependencies in sunstone.gemspec
+# Specify your gem's dependencies in activerecord-filter.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # ActiveRecord::Filter
 
-`ActiveRecord::Filter` provides and easy way to accept user input and filter a query by the input.
+`ActiveRecord::Filter` provides an easy way to accept user input and filter a query by that input.
 
-Installtion
------------
+## Requirements
+
+- Ruby >= 3.3
+- ActiveRecord >= 8.0
+
+## Installation
 
 - Add `gem 'activerecord-filter', require: 'active_record/filter'`
 - Run `bundle install`
@@ -124,10 +128,39 @@ Property.filter("metadata.key": { eq: 'value' }).to_sql
 # => "...WHERE "properties"."metadata" #> '{key}' = 'value'..."
 ```
 
-It can also sort on relations:
+It can also filter across associations. Any association (`belongs_to`,
+`has_many`, `has_one`, `has_and_belongs_to_many`, `has_many :through`) can be
+nested, and the join is added for you:
 
 ```ruby
 Photo.filter(property: {name: 'Empire State'}).to_sql
 # => "... LEFT OUTER JOIN properties ON properties.id = photos.property_id ...
 # => "... WHERE properties.name = 'Empire State'"
+```
+
+Pass `true`/`false` against an association to filter on its presence:
+
+```ruby
+Account.filter(photos: true).to_sql   # accounts that have photos
+Account.filter(photos: false).to_sql  # accounts with no photos
+```
+
+For a polymorphic association, scope it to a type with `as:`:
+
+```ruby
+View.filter(subject: {as: 'Property', name: 'Name'}).to_sql
+```
+
+Combining conditions with AND / OR
+----------------------------------
+
+Pass an array to group conditions. Use the strings `'AND'` / `'OR'` as
+separators, and nest arrays for precedence:
+
+```ruby
+Property.filter([{id: 10}, 'OR', {name: 'name'}]).to_sql
+# => "... WHERE ((properties.id = 10) OR (properties.name = 'name'))"
+
+Property.filter([{id: 10}, 'AND', [{id: 10}, 'OR', {name: 'name'}]]).to_sql
+# => "... WHERE properties.id = 10 AND ((properties.id = 10) OR (properties.name = 'name'))"
 ```

--- a/activerecord-filter.gemspec
+++ b/activerecord-filter.gemspec
@@ -10,11 +10,19 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A safe way to accept user parameters and query against your ActiveRecord Models}
   spec.summary       = %q{A safe way to accept user parameters and query against your ActiveRecord Models}
 
+  spec.metadata = {
+    'homepage_uri'          => spec.homepage,
+    'source_code_uri'       => spec.homepage,
+    'changelog_uri'         => "#{spec.homepage}/blob/master/CHANGELOG.md",
+    'rubygems_mfa_required' => 'true'
+  }
+
+  spec.required_ruby_version = '>= 3.3'
+
   spec.extra_rdoc_files = %w(README.md)
   spec.rdoc_options.concat ['--main', 'README.md']
 
   spec.files         = `git ls-files -- README.md {lib,ext}/*`.split("\n")
-  spec.test_files    = `git ls-files -- {test}/*`.split("\n")
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'activerecord', '>= 8.0.0'

--- a/activerecord-filter.gemspec
+++ b/activerecord-filter.gemspec
@@ -17,18 +17,18 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test}/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', '>= 7.2.0'
-  spec.add_runtime_dependency 'arel-extensions', '>= 7.2.0'
+  spec.add_runtime_dependency 'activerecord', '>= 8.0.0'
+  spec.add_runtime_dependency 'arel-extensions', '>= 8.0.0'
 
   spec.add_development_dependency 'pg'
-  spec.add_development_dependency 'actionpack', '>= 7.2.0'
+  spec.add_development_dependency 'actionpack', '>= 8.0.0'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency "benchmark"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "railties", '>= 7.2.0'
+  spec.add_development_dependency "railties", '>= 8.0.0'
   spec.add_development_dependency "faker"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "activerecord-postgis-adapter"

--- a/lib/active_record/filter/version.rb
+++ b/lib/active_record/filter/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Filter
-    VERSION = '8.1.0'
+    VERSION = '9.0.0'
   end
 end


### PR DESCRIPTION
Ports the modernization from [arel-extensions#11](https://github.com/malomalo/arel-extensions/pull/11) to this repo, and preps a 9.0.0 release.

## Versioning
- **Switch to independent Semantic Versioning**; bump to **9.0.0**. The version no longer maps to a Rails version.
- Add `CHANGELOG.md` (Keep a Changelog style).

## CI
- **Drop Rails 7.2**; test the **8.0** and **8.1** series, resolving the latest patch automatically (gemspec `~> X.0` for the bundle job; latest released tag at clone time for the AR-suite jobs). Gemspec floors bumped to `>= 8.0.0`.
- Scope `on:` to `master` + cancel-in-progress concurrency group.
- Quote all matrix version values (avoid YAML `8.0`→`8` coercion).
- Postgres keyring instead of deprecated `apt-key` (removed on ubuntu-24.04).
- Guard the sed/injections so a silent no-op fails the build.
- MySQL runs as a service container (`mysql:8.4`).
- `actions/checkout` v4 → v7; keep `ruby/setup-ruby@v1`.
- Remove the dead postgis-adapter step.

## Gemspec
- Add `metadata` (source / changelog / MFA-required), declare `required_ruby_version >= 3.3`, drop the deprecated `test_files` declaration.

## Docs
- README: fix typos, correct the "sort on relations" example (it filters across associations), document requirements, association presence, polymorphic `as:`, and AND/OR grouping. All examples verified against the test suite.

## Notes
- The MySQL service-container switch relies on the AR test suite reading `MYSQL_HOST`/`MYSQL_PORT`, same as the arel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)