### PR TITLE
Require arel-extensions >= 9.0.1 (GHSA-75hc-9q9v-9cv2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,13 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install postgresql-${{ matrix.postgres-version }}-postgis-3
           sudo systemctl start postgresql@${{ matrix.postgres-version }}-main.service
+          # The AR suite can exceed the default 100 connection slots depending on
+          # the minitest seed (pool/isolated cases in flight), which cascades into
+          # hundreds of "too many clients already" errors. Give it headroom.
+          sudo -u postgres psql -c "ALTER SYSTEM SET max_connections = 500;"
+          sudo systemctl restart postgresql@${{ matrix.postgres-version }}-main.service
           sudo systemctl status postgresql@${{ matrix.postgres-version }}-main.service
+          sudo -u postgres psql -c "SHOW max_connections;"
           sudo pg_lsclusters
           sudo -u postgres createuser runner --superuser
           sudo -u postgres psql -c "ALTER USER runner WITH PASSWORD 'runner';"
@@ -87,7 +93,13 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install postgresql-${{ matrix.postgres-version }}-postgis-3
           sudo systemctl start postgresql@${{ matrix.postgres-version }}-main.service
+          # The AR suite can exceed the default 100 connection slots depending on
+          # the minitest seed (pool/isolated cases in flight), which cascades into
+          # hundreds of "too many clients already" errors. Give it headroom.
+          sudo -u postgres psql -c "ALTER SYSTEM SET max_connections = 500;"
+          sudo systemctl restart postgresql@${{ matrix.postgres-version }}-main.service
           sudo systemctl status postgresql@${{ matrix.postgres-version }}-main.service
+          sudo -u postgres psql -c "SHOW max_connections;"
           sudo pg_lsclusters
           sudo -u postgres createuser runner --superuser
           sudo -u postgres psql -c "ALTER USER runner WITH PASSWORD 'runner';"
@@ -253,6 +265,13 @@ jobs:
     steps:
       - name: Setup MySQL user
         run: |
+          # Match the headroom given to the Postgres jobs: the pool and forked
+          # isolated cases are adapter-agnostic, so the same seed-dependent
+          # connection exhaustion is possible here on the default 151 slots.
+          # max_connections is dynamic, so no restart is needed -- but MySQL
+          # silently clamps it when open_files_limit is low, hence the echo.
+          mysql -h127.0.0.1 -P3306 -uroot -e "SET GLOBAL max_connections = 500;"
+          mysql -h127.0.0.1 -P3306 -uroot -e "SELECT @@max_connections;"
           mysql -h127.0.0.1 -P3306 -uroot -e "CREATE USER 'rails'@'%';"
           mysql -h127.0.0.1 -P3306 -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%' WITH GRANT OPTION;"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   back to `'{key}'::text[]`, so expression indexes written against the literal
   form still match.
 
+### CI
+- Raise `max_connections` to 500 on the Postgres and MySQL jobs. The ActiveRecord
+  suite can exhaust the 100-slot PGDG default depending on the minitest seed,
+  cascading into hundreds of "too many clients already" errors unrelated to the
+  gem. Ported from malomalo/arel-extensions#13.
+
 ## [9.0.0] - 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- Require `arel-extensions` >= 9.0.1, which fixes a SQL injection in JSON path
+  handling (GHSA-75hc-9q9v-9cv2). A filter key such as `"metadata.subkey"` was
+  interpolated into the `#>'{...}'` array literal unescaped, so an
+  attacker-controlled key could break out of the path and inject SQL.
+
+### Changed
+- JSON path predicates now render as `#> array['key']` instead of
+  `#>'{key}'` (the arel-extensions fix above). PostgreSQL const-folds the array
+  back to `'{key}'::text[]`, so expression indexes written against the literal
+  form still match.
+
 ## [9.0.0] - 2026-08-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Property.filter(metadata: { has_any_key: ['key1', 'key2'] }).to_sql
 # => "...WHERE "properties"."metadata" ?| array['key1', 'key2']..."
 
 Property.filter("metadata.key": { eq: 'value' }).to_sql
-# => "...WHERE "properties"."metadata" #> '{key}' = 'value'..."
+# => "...WHERE "properties"."metadata" #> array['key'] = 'value'..."
 ```
 
 It can also filter across associations. Any association (`belongs_to`,

--- a/activerecord-filter.gemspec
+++ b/activerecord-filter.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'activerecord', '>= 8.0.0'
-  spec.add_runtime_dependency 'arel-extensions', '>= 8.0.0'
+  spec.add_runtime_dependency 'arel-extensions', '>= 9.0.1'
 
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'actionpack', '>= 8.0.0'

--- a/test/filter_column_test/json_test.rb
+++ b/test/filter_column_test/json_test.rb
@@ -58,7 +58,25 @@ class JsonFilterTest < ActiveSupport::TestCase
     assert_equal(<<-SQL.strip.gsub(/\s+/, ' '), query.to_sql.strip)
       SELECT "properties".*
       FROM "properties"
-      WHERE "properties"."metadata"#>'{subkey}' = 'string'
+      WHERE "properties"."metadata" #> array['subkey'] = 'string'
+    SQL
+  end
+  
+  test "::filter json_column.subkey.subkey: {eq: JSON_HASH}" do
+    query = Property.filter("metadata.subkey.nested" => {eq: 'string'})
+    assert_equal(<<-SQL.strip.gsub(/\s+/, ' '), query.to_sql.strip)
+      SELECT "properties".*
+      FROM "properties"
+      WHERE "properties"."metadata" #> array['subkey','nested'] = 'string'
+    SQL
+  end
+  
+  test "::filter json_column.subkey quotes the key (GHSA-75hc-9q9v-9cv2)" do
+    query = Property.filter("metadata.a'} = 'x' OR 1=1 --" => {eq: 'string'})
+    assert_equal(<<-SQL.strip.gsub(/\s+/, ' '), query.to_sql.strip)
+      SELECT "properties".*
+      FROM "properties"
+      WHERE "properties"."metadata" #> array['a''} = ''x'' OR 1=1 --'] = 'string'
     SQL
   end
   


### PR DESCRIPTION
Picks up [arel-extensions 9.0.1](https://github.com/malomalo/arel-extensions/pull/12), which fixes a SQL injection in JSON path handling — **reachable through this gem**.

A dotted filter key was interpolated into the `#>'{...}'` array literal unescaped:

```ruby
Property.filter("metadata.a'} = 'x' OR 1=1 --" => { eq: 'string' })
```

...so an attacker-controlled key could break out of the path and inject SQL. The fix emits `#> array['a']` with each segment run through the visitor's quote helper. PostgreSQL const-folds the array back to `'{a}'::text[]`, so expression indexes written against the literal form still match.

## Changes

- **gemspec:** `arel-extensions` floor `>= 8.0.0` → `>= 9.0.1`.
- **test:** the one affected expectation in `test/filter_column_test/json_test.rb` now reads `"properties"."metadata" #> array['subkey'] = 'string'`.
- **test:** two regression tests added — a nested path (`metadata.subkey.nested` → `array['subkey','nested']`) and the injection attempt above, which now renders fully quoted inside the array element.
- **README:** the documented `to_sql` output still showed the old `#> '{key}'` form.
- **CHANGELOG:** new `[Unreleased]` section. No release cut here.

## CI: raise `max_connections` to 500

Ports [malomalo/arel-extensions#13](https://github.com/malomalo/arel-extensions/pull/13). The first run on this PR had `ActiveRecord PostgresQL Test (8.1, 3.4, 18)` fail with `10065 runs, 0 failures, 182 errors` — 180 of them one cascade from `FATAL: sorry, too many clients already`, then pool timeouts and aborted transactions. Nothing in that log touches arel-extensions; master ran the same Rails tag (`v8.1.3.1`) and the same 10065 cases with 0 errors, and PG 8.0 passed in the same run with the same gems.

The workflow never tuned `max_connections`, so the server ran at the PGDG default of 100, and some minitest seeds cluster the connection-hungry AR cases tightly enough to exhaust it. Postgres needs a live server for `ALTER SYSTEM` and a full restart (not a reload) for `max_connections`, so the sequence is start → alter → restart. MySQL is a service container, which takes no args, but `max_connections` is a dynamic global so `SET GLOBAL` in the existing setup step does it. Both echo the effective value — the original failure was hard to attribute because the cap appeared nowhere in the log, and MySQL silently clamps the value when `open_files_limit` is low.

The MySQL half is hardening, not a fix: its 151-slot default is more headroom and no MySQL log here shows `Too many connections`.

## Testing

`bundle exec rake test` — 80 tests, 112 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)