### PR TITLE
Make relative date/time filtering opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Unreleased
 
 ### Added
-- Relative date/time filtering on `date`/`datetime`/`time`/`timestamp` columns.
-  Values may be the keywords `now`, `today`, `yesterday` and `tomorrow`, or a
-  Hash with an `at` anchor plus any of the `add`, `subtract`, `start_of` and
-  `end_of` operations — e.g. `filter(created_at: {gt: {at: 'now', subtract: '1
-  month', start_of: 'month'}})`. See the README for the full syntax.
+- Opt-in relative date/time filtering on `date`/`datetime`/`time`/`timestamp`
+  columns, enabled with `ActiveRecord::Filter::RelativeTime.enable!` from an
+  initializer. Values may be the keywords `now`, `today`, `yesterday` and
+  `tomorrow`, or a Hash with an `at` anchor plus any of the `add`, `subtract`,
+  `start_of` and `end_of` operations — e.g.
+  `filter(created_at: {gt: {at: 'now', subtract: '1 month', start_of: 'month'}})`.
+  Until `enable!` is called nothing is resolved and filtering is unchanged. See
+  the README for the full syntax.
 
 ## [9.0.0] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,20 @@ Property.filter("metadata.key": { eq: 'value' }).to_sql
 Relative dates and times
 ------------------------
 
-Date and time columns (`date`, `datetime`, `time`, `timestamp`) accept values
-that are resolved relative to the current time, so a saved filter keeps meaning
-the same thing as time passes. Everything is computed in `Time.zone`.
+This is opt-in. Turn it on once, in an initializer:
+
+```ruby
+# config/initializers/activerecord_filter.rb
+ActiveRecord::Filter::RelativeTime.enable!
+```
+
+Until you do, none of the values below are given any special meaning and every
+filter behaves exactly as it does without this feature.
+
+Once enabled, date and time columns (`date`, `datetime`, `time`, `timestamp`)
+accept values that are resolved relative to the current time, so a saved filter
+keeps meaning the same thing as time passes. Everything is computed in
+`Time.zone`.
 
 The keywords `now`, `today`, `yesterday` and `tomorrow` can be used anywhere a
 time is expected:

--- a/lib/active_record/filter.rb
+++ b/lib/active_record/filter.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Filter
   autoload :FilterClauseFactory, 'active_record/filter/filter_clause_factory'
   autoload :RelationExtension, 'active_record/filter/relation_extension'
   autoload :PredicateBuilderExtension, 'active_record/filter/predicate_builder_extension'
-  autoload :RelativeTimeExtension, 'active_record/filter/relative_time_extension'
+  autoload :RelativeTime, 'active_record/filter/relative_time'
   autoload :SpawnMethodsExtension, 'active_record/filter/spawn_methods_extension'
   
   delegate :filter, :filter_for, to: :all

--- a/lib/active_record/filter/predicate_builder_extension.rb
+++ b/lib/active_record/filter/predicate_builder_extension.rb
@@ -170,10 +170,8 @@ module ActiveRecord::Filter::PredicateBuilderExtension
       else
         geometry_from_value(value)
       end
-    elsif ActiveRecord::Filter::RelativeTimeExtension.applies_to?(column)
-      value = ActiveRecord::Filter::RelativeTimeExtension.resolve_filter_value(value)
     end
-
+    
     if value.is_a?(Hash)
       nodes = value.map do |subkey, subvalue|
         expand_filter_for_arel_attribute(column, attribute, subkey, subvalue)

--- a/lib/active_record/filter/relative_time.rb
+++ b/lib/active_record/filter/relative_time.rb
@@ -5,6 +5,10 @@ module ActiveRecord::Filter
   # Resolves "relative" date/time filter values into concrete `Time`s before
   # they are handed to Arel.
   #
+  # Opt-in. Nothing here runs until an initializer turns it on:
+  #
+  #   ActiveRecord::Filter::RelativeTime.enable!
+  #
   # A relative value is either a keyword:
   #
   #   Property.filter(created_at: {gt: 'now'})
@@ -23,7 +27,21 @@ module ActiveRecord::Filter
   #
   # Only columns of a date/time type are inspected, so nothing here can change
   # the meaning of a filter on any other column.
-  module RelativeTimeExtension
+  module RelativeTime
+
+    # Prepended to ActiveRecord::PredicateBuilder by .enable!. Resolving the
+    # value here — before the filter's own column expansion builds any Arel —
+    # means every predicate (gt, in, bare equality, ...) picks up relative
+    # values with no further changes.
+    module PredicateBuilderExtension
+      def expand_filter_for_column(key, column, value, relation_trail)
+        if RelativeTime.enabled? && RelativeTime.applies_to?(column)
+          value = RelativeTime.resolve_filter_value(value)
+        end
+
+        super
+      end
+    end
 
     # Column types whose values may be relative.
     COLUMN_TYPES = %i[date datetime time timestamp timestamptz].freeze
@@ -60,6 +78,28 @@ module ActiveRecord::Filter
     DURATION_FORMAT = /\A\s*#{DURATION_PART}(?:\s*,?\s*#{DURATION_PART})*\s*\z/
 
     class << self
+
+      # Turn relative date/time filtering on for the process. Call from an
+      # initializer. Idempotent.
+      def enable!
+        unless @installed
+          ActiveRecord::PredicateBuilder.prepend(PredicateBuilderExtension)
+          @installed = true
+        end
+
+        @enabled = true
+      end
+
+      # Turn it off again. The prepend stays — a module cannot be
+      # un-prepended — so the patch remains in the ancestor chain and simply
+      # defers to `super`. Mainly here so tests can scope the feature.
+      def disable!
+        @enabled = false
+      end
+
+      def enabled?
+        !!@enabled
+      end
 
       def applies_to?(column)
         COLUMN_TYPES.include?(column.type)

--- a/test/filter_column_test/relative_time_test.rb
+++ b/test/filter_column_test/relative_time_test.rb
@@ -9,9 +9,19 @@ class RelativeTimeFilterTest < ActiveSupport::TestCase
       t.datetime "created_at", null: false
       t.date     "opened_on"
     end
+
+    create_table "photos", force: :cascade do |t|
+      t.integer  "property_id"
+      t.datetime "created_at", null: false
+    end
   end
 
   class Property < ActiveRecord::Base
+    has_many :photos
+  end
+
+  class Photo < ActiveRecord::Base
+    belongs_to :property
   end
 
   NOW = Time.utc(2026, 8, 27, 14, 23, 45)
@@ -20,9 +30,11 @@ class RelativeTimeFilterTest < ActiveSupport::TestCase
     @original_zone = Time.zone
     Time.zone = 'UTC'
     travel_to NOW
+    ActiveRecord::Filter::RelativeTime.enable!
   end
 
   teardown do
+    ActiveRecord::Filter::RelativeTime.disable!
     travel_back
     Time.zone = @original_zone
   end
@@ -237,5 +249,32 @@ class RelativeTimeFilterTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::UnkownFilterError) do
       Property.filter(created_at: {gt: {at: 'now', add: 'a week'}}).to_sql
     end
+  end
+
+  # --- the opt-in itself ---
+
+  test "disabled, a relative value is left to ActiveRecord" do
+    ActiveRecord::Filter::RelativeTime.disable!
+
+    # The guarantee that matters: with the feature off, nothing in this module
+    # touches the value, so upgrading cannot change an existing filter.
+    refute_includes Property.filter(created_at: {gt: "now"}).to_sql, format_time(NOW)
+  end
+
+  test "enable! is idempotent" do
+    ActiveRecord::Filter::RelativeTime.enable!
+    ActiveRecord::Filter::RelativeTime.enable!
+
+    occurrences = ActiveRecord::PredicateBuilder.ancestors.count do |mod|
+      mod == ActiveRecord::Filter::RelativeTime::PredicateBuilderExtension
+    end
+
+    assert_equal 1, occurrences
+  end
+
+  test "the global switch covers filters across associations" do
+    # Nested builders are built from the associated class, so this only works
+    # because enable! patches the shared PredicateBuilder rather than a model.
+    assert_includes Property.filter(photos: {created_at: {gt: "now"}}).to_sql, format_time(NOW)
   end
 end


### PR DESCRIPTION
**Targets #29, not `master`.** This stacks on the relative date/time filtering branch.

PR #29 wires relative date/time resolution into `expand_filter_for_column` unconditionally, so it runs for every filter on every `date`/`datetime`/`time` column whether or not the app wants it. For a gem whose pitch is "a safe way to accept user parameters," a feature that reinterprets incoming strings should be something you turn on deliberately.

```ruby
# config/initializers/activerecord_filter.rb
ActiveRecord::Filter::RelativeTime.enable!
```

Until that runs, nothing is resolved and every filter behaves exactly as it does today.

## How

`enable!` prepends a small module to `ActiveRecord::PredicateBuilder`, which already `include`s `PredicateBuilderExtension`. The ancestor chain becomes `[patch, PredicateBuilder, PredicateBuilderExtension]`, so `super` from the patch reaches the original `expand_filter_for_column`.

Nested builders are constructed with `self.class.new` in `new_predicate_builder_extension`, so the one switch covers filters across associations for free. A per-model flag would have needed threading through `expand_filter_for_relationship`, and would still have surprised people who enabled it on the root model.

Behaviour is gated on a **flag checked at call time**, not merely on whether the prepend happened. `Module#prepend` is permanent for the process, so without the flag a single test file calling `enable!` would leak the feature into every file loaded after it. It costs one boolean check per date-column filter and makes the feature genuinely scopeable.

`predicate_builder_extension.rb` comes back to a **zero-line diff against `master`** — the three lines #29 added there are gone.

## Naming

`RelativeTimeExtension` → `RelativeTime`. Every other `*Extension` in this gem is a mixin (`filter.rb:34-39` prepends or includes them) and this module was not one. It now genuinely has a mixin, and that mixin is the nested `RelativeTime::PredicateBuilderExtension`, so the names line up.

## Tests

All 24 existing cases keep passing, with the feature scoped to the file via `enable!`/`disable!` in `setup`/`teardown`. Three added:

- **disabled is inert** — with `disable!`, `{gt: 'now'}` is left to ActiveRecord's casting. This is the guarantee that upgrading changes nothing.
- **`enable!` is idempotent** — calling it twice leaves one copy of the patch in `ancestors`.
- **the global switch covers associations** — `Property.filter(photos: {created_at: {gt: 'now'}})` resolves, exercising the nested-builder path.

`datetime_test.rb` never calls `enable!` and is the natural regression check.

## Verification

```
relative_time_test.rb   27 tests, 55 assertions, 0 failures
rake test              105 tests, 1 failure
```

That one failure is `json_test.rb`'s `#> array['subkey']` vs `#>'{subkey}'` SQL formatting. It is present unchanged on this PR's base branch — confirmed by running `json_test.rb` on `relative-date-filtering` — and is an arel-extensions formatting difference, not related to this change.

## Landing order

This stack has to land in order. If #29 merges first GitHub will retarget this to `master` automatically, but the diff will need a rebase. If you would rather not maintain a stack, say so and I will push these commits onto `relative-date-filtering` so #29 carries them instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)